### PR TITLE
chore: use companystylesheet `herz.svg` in `icon-heart` component

### DIFF
--- a/src/lib/components/shared/icon-heart.svelte
+++ b/src/lib/components/shared/icon-heart.svelte
@@ -1,15 +1,16 @@
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="20"
-  height="20"
-  viewBox="0 0 24 24"
-  fill="none"
-  stroke="rgb(0 0 0 / 0.7)"
-  stroke-width="2"
-  stroke-linecap="round"
-  stroke-linejoin="round"
-  class="lucide lucide-heart mx-1"
-  ><path
-    d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z"
-  /></svg
->
+<script lang="ts">
+  import { base } from "$app/paths";
+
+  export let width = "16";
+  export let height = "16";
+  export let stroke = "rgb(0 0 0 / 0.7)";
+</script>
+
+<img
+  src="{base}/companystylesheet/icons/herz.svg"
+  {width}
+  {height}
+  alt="Heart icon"
+  style="stroke: {stroke}"
+  class="mx-1"
+/>


### PR DESCRIPTION
so behalten wir unseren component based approach und haben ein bisschen mehr Kontrolle über das svg. Sollen wir bei EBD/AHB-Tabellen bestenfalls auch so machen.