### PR TITLE
ci: remove PAT references from workflows

### DIFF
--- a/.github/workflows/azure-static-web-apps-brave-ocean-076b69903.yml
+++ b/.github/workflows/azure-static-web-apps-brave-ocean-076b69903.yml
@@ -19,9 +19,6 @@ jobs:
         with:
           submodules: "recursive"
           lfs: false
-          token: ${{secrets.COMPANYSTYLESHEET_ACCESS_TOKEN}} # expires 2026-02-01
-          # https://github.com/Hochfrequenz/fristenkalender-frontend/settings/secrets/actions/COMPANYSTYLESHEET_ACCESS_TOKEN
-          # PAT has repo scope
       - name: Set build and release information
         id: build_release_info
         run: |

--- a/.github/workflows/azure-static-web-apps-icy-stone-001be1b03.yml
+++ b/.github/workflows/azure-static-web-apps-icy-stone-001be1b03.yml
@@ -14,9 +14,6 @@ jobs:
         with:
           submodules: "recursive"
           lfs: false
-          token: ${{secrets.COMPANYSTYLESHEET_ACCESS_TOKEN}} # expires 2026-02-01
-          # https://github.com/Hochfrequenz/fristenkalender-frontend/settings/secrets/actions/COMPANYSTYLESHEET_ACCESS_TOKEN
-          # PAT has repo scope
       - name: Set build and release information
         id: build_release_info
         run: |

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -1,5 +1,4 @@
 name: "Building"
-
 on:
   push:
     branches:
@@ -7,7 +6,6 @@ on:
   pull_request:
     branches:
       - main
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -18,17 +16,12 @@ jobs:
           fetch-depth: 0
           submodules: "recursive"
           lfs: false
-          token: ${{secrets.COMPANYSTYLESHEET_ACCESS_TOKEN}} # expires 2026-02-01
-          # https://github.com/Hochfrequenz/fristenkalender-frontend/settings/secrets/actions/COMPANYSTYLESHEET_ACCESS_TOKEN
-          # PAT has repo scope
       - uses: actions/setup-node@v4
         with:
           node-version: "20.13"
           cache: "npm"
-
       - name: Install modules
         run: npm ci
-
       - name: Build frontend
         env:
           BASE_PATH: "/${{ github.event.repository.name }}"

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,9 +18,6 @@ jobs:
           fetch-depth: 1
           submodules: "recursive"
           lfs: false
-          token: ${{secrets.COMPANYSTYLESHEET_ACCESS_TOKEN}} # expires 2026-02-01
-          # https://github.com/Hochfrequenz/fristenkalender-frontend/settings/secrets/actions/COMPANYSTYLESHEET_ACCESS_TOKEN
-          # PAT has repo scope
       - uses: actions/setup-node@v4
         with:
           node-version: "20.13"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,9 +19,6 @@ jobs:
           fetch-depth: 0
           submodules: "recursive"
           lfs: false
-          token: ${{secrets.COMPANYSTYLESHEET_ACCESS_TOKEN}} # expires 2026-02-01
-          # https://github.com/Hochfrequenz/fristenkalender-frontend/settings/secrets/actions/COMPANYSTYLESHEET_ACCESS_TOKEN
-          # PAT has repo scope
       - uses: actions/setup-node@v4
         with:
           node-version: "20.13"


### PR DESCRIPTION
since `company style sheets` is no longer a private repository