### PR TITLE
fix: use German Umlaut `ä` for März

### DIFF
--- a/src/routes/fristenkalender/+page.svelte
+++ b/src/routes/fristenkalender/+page.svelte
@@ -20,7 +20,7 @@
   const monthNameMap: Record<MonthValue, string> = {
     "01": "januar",
     "02": "februar",
-    "03": "maerz",
+    "03": "märz",
     "04": "april",
     "05": "mai",
     "06": "juni",


### PR DESCRIPTION
<img width="724" alt="image" src="https://github.com/user-attachments/assets/5316eb81-4d9d-4562-b8ba-60407e2c412e" />