### PR TITLE
fix(ui): move "Glossar" text slighty to the left so it's not hidden

### DIFF
--- a/src/lib/components/features/glossary-toggle.svelte
+++ b/src/lib/components/features/glossary-toggle.svelte
@@ -25,7 +25,7 @@
         >
           <span
             class="block -rotate-180 font-medium text-black/70"
-            style="writing-mode: vertical-rl;"
+            style="writing-mode: vertical-rl; margin-left: -20px;"
           >
             GLOSSAR
           </span>


### PR DESCRIPTION
nothing to be proud of
fixes #205
![{142CBA59-7A1E-41A4-8233-5E86FBD317F7}](https://github.com/user-attachments/assets/84c1fcca-313a-4587-bb70-c24a18e93d28)
