### PR TITLE
feat: add MCP-Integration page promoting the /mcp server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7545,6 +7545,21 @@
         }
       }
     },
+    "node_modules/svelte-check/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/svelte-eslint-parser": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.4.0.tgz",

--- a/src/lib/components/shared/footer.svelte
+++ b/src/lib/components/shared/footer.svelte
@@ -122,6 +122,13 @@
         >
         |
         <a class="mx-2 hover:underline" href="{base}/mcp-integration/">MCP</a>
+        |
+        <a
+          class="mx-2 hover:underline"
+          target="_blank"
+          rel="noopener noreferrer"
+          href="{API_BASE_URL}/docs">API-Docs</a
+        >
       </p>
     </div>
   </div>

--- a/src/lib/components/shared/footer.svelte
+++ b/src/lib/components/shared/footer.svelte
@@ -118,7 +118,7 @@
           target="_blank"
           rel="noopener noreferrer"
           href="https://github.com/Hochfrequenz/fristenkalender-frontend/"
-          >Github</a
+          >GitHub</a
         >
         |
         <a class="mx-2 hover:underline" href="{base}/mcp-integration/">MCP</a>

--- a/src/lib/components/shared/footer.svelte
+++ b/src/lib/components/shared/footer.svelte
@@ -120,6 +120,8 @@
           href="https://github.com/Hochfrequenz/fristenkalender-frontend/"
           >Github</a
         >
+        |
+        <a class="mx-2 hover:underline" href="{base}/mcp-integration/">MCP</a>
       </p>
     </div>
   </div>

--- a/src/lib/components/shared/footer.svelte
+++ b/src/lib/components/shared/footer.svelte
@@ -127,7 +127,7 @@
           class="mx-2 hover:underline"
           target="_blank"
           rel="noopener noreferrer"
-          href="{API_BASE_URL}/docs">API-Docs</a
+          href="{API_BASE_URL}/docs">API</a
         >
       </p>
     </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,7 +10,11 @@
   import auth from "$src/auth/authService";
   import { isAuthenticated } from "$src/store";
 
-  const exposedEndpoints = [`${base}/`, `${base}/version/`];
+  const exposedEndpoints = [
+    `${base}/`,
+    `${base}/version/`,
+    `${base}/mcp-integration/`,
+  ];
 
   onMount(async () => {
     await auth.createClient();

--- a/src/routes/mcp-integration/+page.svelte
+++ b/src/routes/mcp-integration/+page.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+  import { base } from "$app/paths";
+  import { API_BASE_URL } from "$lib/config/api";
+
+  // The MCP server is served by the backend API (not the frontend origin), at /mcp.
+  const mcpUrl = `${API_BASE_URL}/mcp`;
+
+  // Ready-to-paste opencode config. Kept as a string so it renders verbatim.
+  const opencodeConfig = `{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "fristenkalender": {
+      "type": "remote",
+      "url": "${mcpUrl}",
+      "enabled": true
+    }
+  }
+}`;
+
+  const claudeCodeSnippet = `claude mcp add --transport http fristenkalender ${mcpUrl}`;
+
+  let copied = false;
+
+  async function copyUrl() {
+    await window.navigator.clipboard.writeText(mcpUrl);
+    copied = true;
+    setTimeout(() => (copied = false), 2000);
+  }
+</script>
+
+<section class="bg-fristenkalender_primary flex-grow overflow-y-auto">
+  <div class="flex justify-center px-4 py-10">
+    <div
+      class="rounded-3xl w-full max-w-2xl bg-fristenkalender_secondary p-8 md:p-12
+      shadow-lg ring-1 ring-black/5"
+    >
+      <h1 class="text-3xl text-black/70 pb-5">MCP-Integration</h1>
+      <h2
+        class="flex text-lg border-b-2 border-fristenkalender_tone text-black/70 pb-3 mb-5 uppercase"
+      >
+        Der Fristenkalender in Ihrem KI-Assistenten
+      </h2>
+
+      <p class="text-black/70 pb-5">
+        Der Fristenkalender steht zusätzlich als <strong>MCP-Server</strong>
+        (Model Context Protocol) bereit. Damit können Sie die BDEW-Fristen- und Arbeitstagsberechnungen
+        direkt in Ihrem KI-Assistenten – etwa Claude, GitHub Copilot oder opencode
+        – abfragen, ohne diese Website zu öffnen.
+      </p>
+
+      <h3 class="text-lg text-black/70 pb-3">Was Sie damit tun können</h3>
+      <p class="text-black/70 pb-2">
+        Kurz gesagt: <strong
+          >alles, was auf dieser Website geht, geht auch per MCP</strong
+        >, nur eben direkt in Ihrem KI-Assistenten. Zum Beispiel:
+      </p>
+      <ul class="list-disc list-inside text-black/70 space-y-1 pb-3">
+        <li>prüfen, ob ein Datum ein BDEW-Arbeitstag ist,</li>
+        <li>den nächsten oder vorherigen Arbeitstag bestimmen,</li>
+        <li>
+          Arbeitstage oder Kalendertage auf ein Datum addieren (Fristen
+          berechnen),
+        </li>
+        <li>
+          alle Fristen eines Jahres erzeugen – für einen Typ (z.&nbsp;B. GPKE,
+          MaBiS) oder gesammelt.
+        </li>
+      </ul>
+      <p class="text-black/70 text-sm opacity-70 pb-6">
+        Der MCP-Server ist wie diese Website kostenfrei nutzbar. Sie müssen sich
+        lediglich anmelden.
+      </p>
+
+      <h3 class="text-lg text-black/70 pb-3">Server-Adresse</h3>
+      <p class="text-black/70 pb-3">
+        Tragen Sie in Ihrem KI-Tool die folgende Adresse als Remote- bzw.
+        HTTP-MCP-Server ein:
+      </p>
+      <div class="flex items-center gap-2 pb-3">
+        <code
+          class="flex-1 break-all bg-white/60 border border-fristenkalender_tone rounded-lg px-3 py-2 font-mono text-xs text-black/80"
+          >{mcpUrl}</code
+        >
+        <button
+          on:click={copyUrl}
+          aria-label={copied ? "Kopiert" : "Adresse kopieren"}
+          class="flex-none rounded-full bg-fristenkalender_primary text-weichesschwarz text-sm px-4 py-2
+            ring-1 ring-black/5 hover:ring-black/10 transition-all duration-300"
+        >
+          {copied ? "Kopiert ✓" : "Kopieren"}
+        </button>
+      </div>
+      <p class="text-black/70 text-sm opacity-70 pb-6">
+        Beim ersten Verbinden öffnet sich gegebenenfalls ein Anmeldefenster.
+        Melden Sie sich dort mit Ihrem gewohnten Hochfrequenz-Konto an (dasselbe
+        Login wie für diese Website; ggf. lassen Sie sich erneut einen
+        6-stelligen Code per E-Mail zuschicken).
+      </p>
+
+      <h3 class="text-lg text-black/70 pb-3">Einrichtung in Ihrem KI-Tool</h3>
+      <p class="text-black/70 pb-3">
+        Die genauen Schritte unterscheiden sich je nach Tool. Folgen Sie der
+        offiziellen Anleitung Ihres KI-Assistenten und tragen Sie dort die oben
+        genannte Server-Adresse ein:
+      </p>
+      <ul class="text-black/70 space-y-4 pb-2">
+        <li>
+          <a
+            class="text-fristenkalender_tone font-medium hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://modelcontextprotocol.io/docs/tutorials/use-remote-mcp-server"
+            >Claude ↗</a
+          >
+          <span class="text-sm opacity-70"
+            >(claude.ai &amp; Claude Desktop – „Custom Connectors")</span
+          >
+        </li>
+        <li>
+          <a
+            class="text-fristenkalender_tone font-medium hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://code.claude.com/docs/en/mcp"
+            >Claude Code (Terminal) ↗</a
+          >
+          <pre
+            class="mt-2 overflow-x-auto bg-white/60 border border-fristenkalender_tone rounded-lg px-3 py-2 font-mono text-xs text-black/80"><code
+              >{claudeCodeSnippet}</code
+            ></pre>
+          <span class="text-sm opacity-70"
+            >Danach im Claude-Prompt <code class="font-mono">/mcp</code> öffnen und
+            „Authenticate" wählen (öffnet das Login-Fenster).</span
+          >
+        </li>
+        <li>
+          <a
+            class="text-fristenkalender_tone font-medium hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://code.visualstudio.com/docs/copilot/chat/mcp-servers"
+            >GitHub Copilot in VS Code ↗</a
+          >
+        </li>
+        <li>
+          <a
+            class="text-fristenkalender_tone font-medium hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://opencode.ai/docs/mcp-servers/">opencode ↗</a
+          >
+          <p class="text-sm opacity-70 mt-1">
+            In Ihre <code class="font-mono">opencode.json</code> eintragen
+            (Repo-Root oder global unter
+            <code class="font-mono">~/.config/opencode/opencode.json</code>):
+          </p>
+          <pre
+            class="mt-2 overflow-x-auto bg-white/60 border border-fristenkalender_tone rounded-lg px-3 py-2 font-mono text-xs text-black/80"><code
+              >{opencodeConfig}</code
+            ></pre>
+          <p class="text-sm opacity-70 mt-1">Danach einmalig anmelden:</p>
+          <pre
+            class="mt-2 overflow-x-auto bg-white/60 border border-fristenkalender_tone rounded-lg px-3 py-2 font-mono text-xs text-black/80"><code
+              >opencode mcp auth fristenkalender</code
+            ></pre>
+        </li>
+      </ul>
+
+      <div
+        class="mt-6 pt-5 border-t-2 border-dashed border-fristenkalender_tone"
+      >
+        <a
+          href="{base}/"
+          class="text-black/70 hover:underline inline-flex items-center gap-1"
+          >← Zurück zur Startseite</a
+        >
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## What & why

Promotes the newly launched **read-only MCP server** (backend: `Hochfrequenz/fristenkalender-functions` #309, released in `v2.3.0`, served at the API's `/mcp`) with a dedicated **MCP-Integration page**, mirroring what `ahb-tabellen` did — reimplemented for this SvelteKit app.

## Changes

- **New page `src/routes/mcp-integration/+page.svelte`** (route `/mcp-integration`): what the MCP server offers (the Fristenkalender/working-day calculations in your AI assistant), the server address with a **copy button**, an Auth0 login note, and setup snippets for **Claude, Claude Code, GitHub Copilot, and opencode**.
- The MCP URL is derived from `API_BASE_URL` (`$lib/config/api`, the backend origin) as `${API_BASE_URL}/mcp` — same source the footer uses for the version lookup — so it resolves per environment (prod → `https://fristenkalender-api.happyfield-64ecc075.westeurope.azurecontainerapps.io/mcp`).
- **Footer link "MCP"** → the page (internal link, like the `version/` link).
- **`+layout.svelte`**: added `${base}/mcp-integration/` to `exposedEndpoints` so the page is reachable without login (like the landing/version pages).

Styling reuses the landing-page card idiom and the Fristenkalender palette (`fristenkalender_primary` / `_secondary` / `_tone`); copy uses German "Sie" form to match the app.

## Verification

- `npm run check` (svelte-check): **0 errors / 0 warnings**
- `npm run lint:check`, `npm run format:check`: **clean**
- `npm run build`: **succeeds**, the route compiles and prerenders
- Independently reviewed (Svelte conventions, auth-guard wiring, scroll/layout, a11y, content accuracy) — merge-ready.

Note: I couldn't capture a headless screenshot in my environment (no browser system libs), so a quick `npm run preview` eyeball of `/mcp-integration/` is worthwhile before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
